### PR TITLE
Enable removal of unused functions to reduce size

### DIFF
--- a/windows/build.gradle
+++ b/windows/build.gradle
@@ -35,7 +35,7 @@ tasks.withType(CppCompile).configureEach {
 }
 
 tasks.withType(AbstractLinkTask).configureEach {
-	linkerArgs.addAll("Rstrtmgr.lib", "User32.lib")
+	linkerArgs.addAll("Rstrtmgr.lib", "User32.lib", "/OPT:REF")
 }
 
 unitTest {


### PR DESCRIPTION
This should reduce (for example) the size of the x86_64 DLL from 700kb to 140kb, the same should apply to the other architectures.

Documentation for `/OPT:REF`:
https://learn.microsoft.com/en-us/cpp/build/reference/opt-optimizations?view=msvc-170

For new Visual Studio 2022 projects, this option is also enabled by default (among others) in release mode (`/OPT:ICF` and `/LTCG` are also enabled but I saw no size benefits)
